### PR TITLE
Fix project name

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-intellij-neon
+intellij-ansible


### PR DESCRIPTION
While cloned from `intellij-neon`, this is `intellij-ansible`.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>